### PR TITLE
Make sure there are no conflicts in the MAME OPL interface

### DIFF
--- a/src/sound_mameopl.c
+++ b/src/sound_mameopl.c
@@ -6,7 +6,6 @@
 #include "mame/fmopl.h"
 #include "mame/ymf262.h"
 #include "sound_opl.h"
-#include "sound_dbopl.h"
 
 /*Interfaces between PCem and the actual OPL emulator*/
 


### PR DESCRIPTION
For the time being, MAME OPL support is nulled out due to heavy sound changes but to make sure, the references to the dbopl header files in the interface are removed to prevent major conflict in compilation if it gets added back in. 